### PR TITLE
Remove the size attribute from the checkbox output

### DIFF
--- a/admin/class-settings-page-admin.php
+++ b/admin/class-settings-page-admin.php
@@ -218,7 +218,7 @@ class Settings_Page_Admin {
 
 					} else {
 							$checked = ($value) ? 'checked' : '';
-							echo '<input type="'.$args['subtype'].'" id="'.$args['id'].'" "'.$args['required'].'" name="'.$args['name'].'" size="40" value="1" '.$checked.' />';
+							echo '<input type="'.$args['subtype'].'" id="'.$args['id'].'" "'.$args['required'].'" name="'.$args['name'].'" value="1" '.$checked.' />';
 					}
 					break;
 			default:


### PR DESCRIPTION
The `size` attribute has no effect on `<input type="checkbox"/>`.